### PR TITLE
Fill in missing payload in publish command

### DIFF
--- a/mowas_mqtt.py
+++ b/mowas_mqtt.py
@@ -57,7 +57,7 @@ def send_mqtt(message, topic):
         mqttclient.username_pw_set(mqtt_user, mqtt_pass)
     mqttclient.connect(mqtt_ipaddress, mqtt_port, 60)
     mqttclient.loop_start()
-    mqttpub = mqttclient.publish(topic, mqtt_qos)
+    mqttpub = mqttclient.publish(topic, payload=message, mqtt_qos)
 
 
 def get_json_as_dict(url):


### PR DESCRIPTION
Hi,

I have cloned your repo and tried to get it working on my side, but it would never publish a message.
I believe the payload is never used in your send_mqtt function - I have added it and it works for me now.

All the best,

Bob from Openhab